### PR TITLE
notifications_enabled = 0 in both regions

### DIFF
--- a/puppetdb_stencil.py
+++ b/puppetdb_stencil.py
@@ -62,11 +62,17 @@ def render_resources(database, resource_type, localsite, template_names):
                 }
                 # capture resource parameters from puppet
                 for key, value in resource.parameters.items():
-                    if (key not in METAPARAMS or key in ALLOWED_METAPARAMS) and (isinstance(value, list)):
-                        dto['parameters'].append({key: ','.join(value)})
-                    else:
-                        dto['parameters'].append({key: value})
-                    envs_to_ignore.append((object_name + '_' + key).upper())
+                    if key not in METAPARAMS or key in ALLOWED_METAPARAMS:
+                        if isinstance(value, list):
+                            dto['parameters'].append({key: ','.join(value)})
+                            envs_to_ignore.append((object_name + '_' + key).upper())
+                        # CIRRUS-4549: a value of 2 is the signal to
+                        # take the environment variable default. A
+                        # value of 0 or 1 should be used as-is from
+                        # puppet.
+                        elif not (key == 'notifications_enabled' and str(value) == '2'):
+                            dto['parameters'].append({key: value})
+                            envs_to_ignore.append((object_name + '_' + key).upper())
                 # capture environment variable defaults
                 for name in os.environ:
                     nameparts = name.split('_')


### PR DESCRIPTION
The previous fix to change environment variables from overrides to
defaults introduced a new bug: notifications_enabled was being set to 0
in both regions. This fix uses a default value of 2 in puppet to signal
puppetdb-stencil to use the environment variable as an override. But if
puppet sets notifications_enabled to 0 or 1, it will be used and the
environment variable will be ignored.

Issue: CIRRUS-4549
